### PR TITLE
update llvmlite requirement

### DIFF
--- a/python_scripts/requirements.txt
+++ b/python_scripts/requirements.txt
@@ -6,5 +6,5 @@ seaborn==0.9
 statsmodels==0.11
 umap-learn==0.3.8
 numba==0.43.1
-llvm-lite==0.28
+llvmlite==0.28
 pyarrow


### PR DESCRIPTION
PyPi cannot find llvm-lite==0.28, but it can install llvmlite==0.28. 

If this is the correct package, then this PR will fix an installation error.